### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Once [installed](#install), you can use the following code to create a simple
 echo server that listens for incoming multicast messages:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $socket = $factory->createReceiver('224.10.20.30:4050');
 
 $socket->on('message', function ($data, $remote) use ($socket) {
@@ -50,7 +49,6 @@ $socket->on('message', function ($data, $remote) use ($socket) {
     $socket->send($data, $remote);
 });
 
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -60,12 +58,16 @@ See also the [examples](examples).
 ### Factory
 
 The `Factory` is responsible for creating your [`SocketInterface`](#socketinterface) instances.
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 ```
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
 
 #### createSender()
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once [installed](#install), you can use the following code to create a simple
 echo server that listens for incoming multicast messages:
 
 ```php
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 $socket = $factory->createReceiver('224.10.20.30:4050');
 
 $socket->on('message', function ($data, $remote) use ($socket) {
@@ -60,7 +60,7 @@ See also the [examples](examples).
 The `Factory` is responsible for creating your [`SocketInterface`](#socketinterface) instances.
 
 ```php
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 ```
 
 This class takes an optional `LoopInterface|null $loop` parameter that can be used to

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/datagram": "~1.0"
     },
     "require-dev": {

--- a/examples/dump-received.php
+++ b/examples/dump-received.php
@@ -18,8 +18,7 @@ if (isset($argv[1])) {
     $address = $argv[1];
 }
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $socket = $factory->createReceiver($address);
 $hex = new Hexdump();
 
@@ -28,4 +27,3 @@ $socket->on('message', function ($data, $remote) use ($hex) {
     echo $hex->dump($data) . PHP_EOL;
 });
 
-$loop->run();

--- a/examples/dump-received.php
+++ b/examples/dump-received.php
@@ -5,9 +5,6 @@
  * Accepts a single argument socket address (defaults to 224.10.20.30:12345)
  */
 
-use Clue\React\Multicast\Factory;
-use Clue\Hexdump\Hexdump;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 $address = '224.10.20.30:12345'; // random test address
@@ -18,9 +15,9 @@ if (isset($argv[1])) {
     $address = $argv[1];
 }
 
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 $socket = $factory->createReceiver($address);
-$hex = new Hexdump();
+$hex = new Clue\Hexdump\Hexdump();
 
 $socket->on('message', function ($data, $remote) use ($hex) {
     echo 'Received from ' . $remote . PHP_EOL;

--- a/examples/echo-received.php
+++ b/examples/echo-received.php
@@ -5,8 +5,6 @@
  * Accepts a single argument socket address (defaults to 224.10.20.30:12345)
  */
 
-use Clue\React\Multicast\Factory;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 $address = '224.10.20.30:12345'; // random test address
@@ -17,7 +15,7 @@ if (isset($argv[1])) {
     $address = $argv[1];
 }
 
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 $socket = $factory->createReceiver($address);
 
 $socket->on('message', function ($data, $remote) use ($socket) {

--- a/examples/echo-received.php
+++ b/examples/echo-received.php
@@ -17,13 +17,10 @@ if (isset($argv[1])) {
     $address = $argv[1];
 }
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $socket = $factory->createReceiver($address);
 
 $socket->on('message', function ($data, $remote) use ($socket) {
     echo 'Sending back ' . strlen($data) . ' bytes to ' . $remote . PHP_EOL;
     $socket->send($data, $remote);
 });
-
-$loop->run();

--- a/examples/send-once.php
+++ b/examples/send-once.php
@@ -11,8 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $address = isset($argv[1]) ? $argv[1] : '224.10.20.30:12345';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $sender = $factory->createSender();
 
 // do not wait for incoming messages
@@ -21,5 +20,3 @@ $sender->pause();
 // send a simple message
 $message = 'ping 123';
 $sender->send($message, $address);
-
-$loop->run();

--- a/examples/send-once.php
+++ b/examples/send-once.php
@@ -5,13 +5,11 @@
  * Accepts a single argument socket address (defaults to 224.10.20.30:12345)
  */
 
-use Clue\React\Multicast\Factory;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 $address = isset($argv[1]) ? $argv[1] : '224.10.20.30:12345';
 
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 $sender = $factory->createSender();
 
 // do not wait for incoming messages

--- a/examples/send-wait.php
+++ b/examples/send-wait.php
@@ -12,8 +12,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $address = isset($argv[1]) ? $argv[1] : '224.10.20.30:12345';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $sender = $factory->createSender();
 $hex = new Hexdump();
 
@@ -26,5 +25,3 @@ $sender->on('message', function ($data, $remote) use ($hex) {
 // send a simple message
 $message = 'ping 123';
 $sender->send($message, $address);
-
-$loop->run();

--- a/examples/send-wait.php
+++ b/examples/send-wait.php
@@ -5,16 +5,13 @@
  * Accepts a single argument socket address (defaults to 224.10.20.30:12345)
  */
 
-use Clue\React\Multicast\Factory;
-use Clue\Hexdump\Hexdump;
-
 require __DIR__ . '/../vendor/autoload.php';
 
 $address = isset($argv[1]) ? $argv[1] : '224.10.20.30:12345';
 
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 $sender = $factory->createSender();
-$hex = new Hexdump();
+$hex = new Clue\Hexdump\Hexdump();
 
 // print a hexdump of every message received
 $sender->on('message', function ($data, $remote) use ($hex) {

--- a/examples/ssdp.php
+++ b/examples/ssdp.php
@@ -3,13 +3,12 @@
  * UPnP simple service discovery protocol (SSDP)
  */
 
-use Clue\React\Multicast\Factory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $address = '239.255.255.250:1900';
 
-$factory = new Factory();
+$factory = new Clue\React\Multicast\Factory();
 $sender = $factory->createSender();
 
 // dump all incoming messages

--- a/examples/ssdp.php
+++ b/examples/ssdp.php
@@ -9,8 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $address = '239.255.255.250:1900';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 $sender = $factory->createSender();
 
 // dump all incoming messages
@@ -20,7 +19,7 @@ $sender->on('message', function ($data, $remote) {
 });
 
 // stop waiting for incoming messages after 3.0s (MX is 2s)
-$loop->addTimer(3.0, function () use ($sender) {
+Loop::addTimer(3.0, function () use ($sender) {
     $sender->pause();
 });
 
@@ -32,5 +31,3 @@ $data .= "MX: 2\r\n";
 $data .= "ST: ssdp:all\r\n";
 $data .= "\r\n";
 $sender->send($data, $address);
-
-$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,6 +2,7 @@
 
 namespace Clue\React\Multicast;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Datagram\Socket as DatagramSocket;
 use BadMethodCallException;
@@ -9,11 +10,17 @@ use RuntimeException;
 
 class Factory
 {
+    /** @var LoopInterface */
     private $loop;
 
     /**
      * The `Factory` is responsible for creating your [`SocketInterface`](#socketinterface) instances.
-     * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
+     * 
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
      *
      * ```php
      * $loop = React\EventLoop\Factory::create();
@@ -22,9 +29,9 @@ class Factory
      *
      * @param LoopInterface $loop
      */
-    public function __construct(LoopInterface $loop)
+    public function __construct(LoopInterface $loop = null)
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
     }
 
     /**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -57,4 +57,15 @@ class FunctionalTest extends TestCase
 
         $this->loop->run();
     }
+    
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Factory();
+        
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+        
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
 }


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229 and reactphp/event-loop#232